### PR TITLE
Removed max-width from breakpoint media queries

### DIFF
--- a/grid.generator.scss
+++ b/grid.generator.scss
@@ -19,15 +19,30 @@ html { box-sizing: border-box; }
   .#{$prefix}pad-#{$i}-top { padding-top: $spaceUnit; }
   .#{$prefix}pad-#{$i}-bottom { padding-bottom: $spaceUnit; }
   .#{$prefix}pad-#{$i}-sides { padding-left: $spaceUnit; padding-right: $spaceUnit; }
-  .#{$prefix}pad-#{$i}-vert { padding-top: $spaceUnit; padding-bottom: $spaceUnit; }
+  .#{$prefix}pad-#{$i}-vertical { padding-top: $spaceUnit; padding-bottom: $spaceUnit; }
   .#{$prefix}marg-#{$i} { margin: $spaceUnit; }
   .#{$prefix}marg-#{$i}-left { margin-left: $spaceUnit; }
   .#{$prefix}marg-#{$i}-right { margin-right: $spaceUnit; }
   .#{$prefix}marg-#{$i}-top { margin-top: $spaceUnit; }
   .#{$prefix}marg-#{$i}-bottom { margin-bottom: $spaceUnit; }
   .#{$prefix}marg-#{$i}-sides { margin-left: $spaceUnit; margin-right: $spaceUnit; }
-  .#{$prefix}marg-#{$i}-vert { margin-top: $spaceUnit; margin-bottom: $spaceUnit; }
+  .#{$prefix}marg-#{$i}-vertical { margin-top: $spaceUnit; margin-bottom: $spaceUnit; }
 }
+
+@mixin utilities($prefix){
+  .#{$prefix}float-left { float: left; }
+  .#{$prefix}float-right { float: right; }
+  .#{$prefix}float-none { float: none; }
+  .#{$prefix}align-center { text-align: center; }
+  .#{$prefix}align-right { text-align: right; }
+  .#{$prefix}align-left { text-align: left; }
+  .#{$prefix}block { display: block; }
+  .#{$prefix}inline { display: inline-block; }
+  .#{$prefix}center-margin { margin: 0 auto; }
+  .#{$prefix}border-box { box-sizing: border-box; }
+
+}
+
 @mixin gridClasses($_prefix:'', $gridColumns:12, $spaceUnits:(8px,16px,32px), $breakpoint_min:'', $breakpoint_max:''){
   
   // grid classes
@@ -89,9 +104,20 @@ html { box-sizing: border-box; }
       $breakpoint_max: nth($breakpoints, $i+1);
     }
 
-    // Makes min-width set for all breakpoints
+  //   //* smallest breakpoint */
     @media (min-width: $breakpoint_min) {
       @include gridClasses($prefix, $gridColumns, $spaceUnits);
+    }
+  }
+
+
+  @for $i from 1 through length($breakpointPrefixes) {
+    $prefix: nth($breakpointPrefixes, $i);
+    $breakpoint_min: nth($breakpoints, $i);
+
+    //* smallest breakpoint */
+    @media (min-width: $breakpoint_min) {
+      @include utilities($prefix);
     }
   }
 }

--- a/grid.generator.scss
+++ b/grid.generator.scss
@@ -13,57 +13,54 @@ html { box-sizing: border-box; }
 *, *:before, *:after { box-sizing: inherit; }
 
 @mixin spacingHelpers($prefix, $i, $spaceUnit){
-  .#{$prefix}pad-#{$i} { padding: $spaceUnit; }
-  .#{$prefix}pad-#{$i}-left { padding-left: $spaceUnit; }
-  .#{$prefix}pad-#{$i}-right { padding-right: $spaceUnit; }
-  .#{$prefix}pad-#{$i}-top { padding-top: $spaceUnit; }
-  .#{$prefix}pad-#{$i}-bottom { padding-bottom: $spaceUnit; }
-  .#{$prefix}pad-#{$i}-sides { padding-left: $spaceUnit; padding-right: $spaceUnit; }
-  .#{$prefix}pad-#{$i}-vertical { padding-top: $spaceUnit; padding-bottom: $spaceUnit; }
-  .#{$prefix}marg-#{$i} { margin: $spaceUnit; }
-  .#{$prefix}marg-#{$i}-left { margin-left: $spaceUnit; }
-  .#{$prefix}marg-#{$i}-right { margin-right: $spaceUnit; }
-  .#{$prefix}marg-#{$i}-top { margin-top: $spaceUnit; }
-  .#{$prefix}marg-#{$i}-bottom { margin-bottom: $spaceUnit; }
-  .#{$prefix}marg-#{$i}-sides { margin-left: $spaceUnit; margin-right: $spaceUnit; }
-  .#{$prefix}marg-#{$i}-vertical { margin-top: $spaceUnit; margin-bottom: $spaceUnit; }
+  %#{$prefix}pad-#{$i} { padding: $spaceUnit; }
+  %#{$prefix}pad-#{$i}-left { padding-left: $spaceUnit; }
+  %#{$prefix}pad-#{$i}-right { padding-right: $spaceUnit; }
+  %#{$prefix}pad-#{$i}-top { padding-top: $spaceUnit; }
+  %#{$prefix}pad-#{$i}-bottom { padding-bottom: $spaceUnit; }
+  %#{$prefix}pad-#{$i}-sides { padding-left: $spaceUnit; padding-right: $spaceUnit; }
+  %#{$prefix}pad-#{$i}-vertical { padding-top: $spaceUnit; padding-bottom: $spaceUnit; }
+  %#{$prefix}marg-#{$i} { margin: $spaceUnit; }
+  %#{$prefix}marg-#{$i}-left { margin-left: $spaceUnit; }
+  %#{$prefix}marg-#{$i}-right { margin-right: $spaceUnit; }
+  %#{$prefix}marg-#{$i}-top { margin-top: $spaceUnit; }
+  %#{$prefix}marg-#{$i}-bottom { margin-bottom: $spaceUnit; }
+  %#{$prefix}marg-#{$i}-sides { margin-left: $spaceUnit; margin-right: $spaceUnit; }
+  %#{$prefix}marg-#{$i}-vertical { margin-top: $spaceUnit; margin-bottom: $spaceUnit; }
 }
 
 @mixin utilities($prefix){
-  .#{$prefix}float-left { float: left; }
-  .#{$prefix}float-right { float: right; }
-  .#{$prefix}float-none { float: none; }
-  .#{$prefix}align-center { text-align: center; }
-  .#{$prefix}align-right { text-align: right; }
-  .#{$prefix}align-left { text-align: left; }
-  .#{$prefix}block { display: block !important; }
-  .#{$prefix}inline-block { display: inline-block !important; }
-  .#{$prefix}inline { display: inline !important; }
-  .#{$prefix}center-margin { margin: 0 auto; }
-  .#{$prefix}border-box { box-sizing: border-box; }
-  .#{$prefix}invisible { display: none !important; }
+  %#{$prefix}float-left { float: left; }
+  %#{$prefix}float-right { float: right; }
+  %#{$prefix}float-none { float: none; }
+  %#{$prefix}align-center { text-align: center; }
+  %#{$prefix}align-right { text-align: right; }
+  %#{$prefix}align-left { text-align: left; }
+  %#{$prefix}block { display: block !important; }
+  %#{$prefix}inline-block { display: inline-block !important; }
+  %#{$prefix}inline { display: inline !important; }
+  %#{$prefix}center-margin { margin: 0 auto; }
+  %#{$prefix}border-box { box-sizing: border-box; }
+  %#{$prefix}invisible { display: none !important; }
 
 }
 
 @mixin gridClasses($_prefix:'', $gridColumns:12, $spaceUnits:(8px,16px,32px), $breakpoint_min:'', $breakpoint_max:''){
   
-  // grid classes
-  .#{$_prefix}grid {
-    margin: 0; clear: none; float: left; 
-  }
   @for $i from 1 through $gridColumns {
-    .#{$_prefix}grid-#{$i} {
-      @extend .#{$_prefix}grid;
+    %#{$_prefix}grid-#{$i} {
+      @extend %#{$_prefix}grid;
       width:percentage($i/$gridColumns);
+      margin: 0; clear: none; float: left; 
     }
   }
 
   // offset classes
-  .#{$_prefix}offset-0 {
+  %#{$_prefix}offset-0 {
     margin-left: 0;
   }
   @for $i from 1 through $gridColumns {
-    .#{$_prefix}offset-#{$i} {
+    %#{$_prefix}offset-#{$i} {
       margin-left:percentage($i/$gridColumns);
     }
   }
@@ -90,6 +87,7 @@ html { box-sizing: border-box; }
 
   //* generate top-level grid classes, no prefix */
   @include gridClasses('', $gridColumns, $spaceUnits);
+  @include utilities('')
 
   @for $i from 1 through length($breakpointPrefixes) {
     $prefix: nth($breakpointPrefixes, $i);
@@ -109,17 +107,12 @@ html { box-sizing: border-box; }
   //   //* smallest breakpoint */
     @media (min-width: $breakpoint_min) {
       @include gridClasses($prefix, $gridColumns, $spaceUnits);
+      @include utilities($prefix);
     }
   }
-
 
   @for $i from 1 through length($breakpointPrefixes) {
     $prefix: nth($breakpointPrefixes, $i);
     $breakpoint_min: nth($breakpoints, $i);
-
-    //* smallest breakpoint */
-    @media (min-width: $breakpoint_min) {
-      @include utilities($prefix);
-    }
   }
 }

--- a/grid.generator.scss
+++ b/grid.generator.scss
@@ -89,20 +89,9 @@ html { box-sizing: border-box; }
       $breakpoint_max: nth($breakpoints, $i+1);
     }
 
-  //   //* smallest breakpoint */
-    @if $breakpoint_min == 1 {
-
-      @media (max-width: $breakpoint_max) {
-        @include gridClasses($prefix, $gridColumns, $spaceUnits);
-      }
-          
-    } @else {
-
-      //* all other breakpoints */
-        @media (min-width: $breakpoint_min) {
-          @include gridClasses($prefix, $gridColumns, $spaceUnits);
-        }
-      }
+    // Makes min-width set for all breakpoints
+    @media (min-width: $breakpoint_min) {
+      @include gridClasses($prefix, $gridColumns, $spaceUnits);
     }
   }
 }

--- a/grid.generator.scss
+++ b/grid.generator.scss
@@ -36,10 +36,12 @@ html { box-sizing: border-box; }
   .#{$prefix}align-center { text-align: center; }
   .#{$prefix}align-right { text-align: right; }
   .#{$prefix}align-left { text-align: left; }
-  .#{$prefix}block { display: block; }
-  .#{$prefix}inline { display: inline-block; }
+  .#{$prefix}block { display: block !important; }
+  .#{$prefix}inline-block { display: inline-block !important; }
+  .#{$prefix}inline { display: inline !important; }
   .#{$prefix}center-margin { margin: 0 auto; }
   .#{$prefix}border-box { box-sizing: border-box; }
+  .#{$prefix}invisible { display: none !important; }
 
 }
 

--- a/grid.generator.scss
+++ b/grid.generator.scss
@@ -98,16 +98,7 @@ html { box-sizing: border-box; }
           
     } @else {
 
-      //* middle breakpoints */
-      @if $breakpoint_max != '' {
-
-        @media (min-width: $breakpoint_min) and (max-width: $breakpoint_max) {
-          @include gridClasses($prefix, $gridColumns, $spaceUnits);
-        }
-
-      //* largest breakpoint */
-      } @else {
-
+      //* all other breakpoints */
         @media (min-width: $breakpoint_min) {
           @include gridClasses($prefix, $gridColumns, $spaceUnits);
         }

--- a/grid.scss
+++ b/grid.scss
@@ -1,5 +1,4 @@
 @import 'grid.generator.scss';
-@include gridGenerator();
 
 // Default settings for gridGenerator()
 //     $gridColumns: 12,                    // number of grid columns 


### PR DESCRIPTION
I noticed that the max-width property in the media queries was limited the grids effectiveness for larger screen sizes. For example, I could have grid breakpoints set that I wanted from the medium screen upwards, but would not work when the screen size reached the next breakpoint. This was since the medium breakpoint was only going up to the maximum width, so I'd have to retype the same grid breakpoints for the larger screen sizes.

I removed the max-width queries from all the breakpoints and tested it on a site I'm developing and it's simplifying my HTML markup a lot. The larger media queries simply overwrite the smaller ones. The medium screen layout options I set now work for that screen size and all larger ones, unless I specify differently.

Thought it'd be a good fix since it's simpler and also closer to what people are familiar with in other grid systems like Bootstrap.
